### PR TITLE
refactor: Add barrel files for @wordbricks/next-eval

### DIFF
--- a/apps/web/scripts/update-mdr-ground-truth.ts
+++ b/apps/web/scripts/update-mdr-ground-truth.ts
@@ -1,7 +1,7 @@
 import { readFile, readdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { runMDRWithDetails } from "@/lib/utils/runMDR";
-import { slimHtml } from "@wordbricks/next-eval/html/utils/slimHtml";
+import { slimHtml } from "@wordbricks/next-eval";
 import { JSDOM } from "jsdom";
 
 /**

--- a/apps/web/src/app/api/apps/llm.ts
+++ b/apps/web/src/app/api/apps/llm.ts
@@ -1,8 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { getLLMResponse } from "@wordbricks/next-eval/llm/utils/getLLMResponse";
-import type { LLMResponse } from "@wordbricks/next-eval/shared/interfaces/LLMResponse";
-import type { PromptType } from "@wordbricks/next-eval/shared/interfaces/types";
+import type { LLMResponse, PromptType } from "@wordbricks/next-eval";
+import { getLLMResponse } from "@wordbricks/next-eval/server";
 import { Hono } from "hono";
 
 const llmApp = new Hono();

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -12,9 +12,11 @@ import DownloadIcon from "@/components/icons/DownloadIcon";
 import ThumbsDownIcon from "@/components/icons/ThumbsDownIcon";
 import ThumbsUpIcon from "@/components/icons/ThumbsUpIcon";
 import { readFileAsText } from "@/lib/utils/readFileAsText";
-import { mapResponseToFullXpath } from "@wordbricks/next-eval/evaluation/utils/mapResponseToFullXpath";
-import { processHtmlContent } from "@wordbricks/next-eval/html/utils/processHtmlContent";
-import type { ExtendedHtmlResult } from "@wordbricks/next-eval/shared/interfaces/HtmlResult";
+import {
+  type ExtendedHtmlResult,
+  mapResponseToFullXpath,
+  processHtmlContent,
+} from "@wordbricks/next-eval";
 import type React from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { v4 as uuidv4 } from "uuid";

--- a/apps/web/src/components/MdrTab.tsx
+++ b/apps/web/src/components/MdrTab.tsx
@@ -5,7 +5,7 @@ import ThumbsDownIcon from "@/components/icons/ThumbsDownIcon";
 import ThumbsUpIcon from "@/components/icons/ThumbsUpIcon";
 import { useMdr } from "@/hooks/useMdr";
 import { Progress } from "@next-eval/ui/components/progress";
-import type { ExtendedHtmlResult } from "@wordbricks/next-eval/shared/interfaces/HtmlResult";
+import type { ExtendedHtmlResult } from "@wordbricks/next-eval";
 import { useState } from "react";
 
 interface MdrTabProps {

--- a/apps/web/src/hooks/useMdr.ts
+++ b/apps/web/src/hooks/useMdr.ts
@@ -6,8 +6,10 @@ import {
   mdrResponseAtom,
 } from "@/atoms/mdr";
 import { runMDR } from "@/lib/utils/runMDR";
-import { mapResponseToFullXpath } from "@wordbricks/next-eval/evaluation/utils/mapResponseToFullXpath";
-import type { ExtendedHtmlResult } from "@wordbricks/next-eval/shared/interfaces/HtmlResult";
+import {
+  type ExtendedHtmlResult,
+  mapResponseToFullXpath,
+} from "@wordbricks/next-eval";
 import { useAtom } from "jotai";
 import { useCallback } from "react";
 

--- a/apps/web/src/lib/utils/runMDR.ts
+++ b/apps/web/src/lib/utils/runMDR.ts
@@ -1,6 +1,8 @@
-import { removeCommentScriptStyleFromHTML } from "@wordbricks/next-eval/html/utils/removeCommentScriptStyleFromHTML";
-import type { TagNode } from "@wordbricks/next-eval/shared/interfaces/TagNode";
-import { buildTagTree } from "@wordbricks/next-eval/shared/utils/buildTagTree";
+import {
+  type TagNode,
+  buildTagTree,
+  removeCommentScriptStyleFromHTML,
+} from "@wordbricks/next-eval";
 import { parse } from "node-html-parser";
 
 // MDR (Mining Data Region) constants

--- a/apps/web/src/lib/utils/wasmLoader.ts
+++ b/apps/web/src/lib/utils/wasmLoader.ts
@@ -1,6 +1,6 @@
 // WASM loader for the complete Rust MDR implementation
 
-import type { TagNode } from "@wordbricks/next-eval/shared/interfaces/TagNode";
+import type { TagNode } from "@wordbricks/next-eval";
 
 export interface RegionsMapItem {
   parent_xpath: string;

--- a/apps/web/tests/mdr-consistency.test.ts
+++ b/apps/web/tests/mdr-consistency.test.ts
@@ -1,8 +1,7 @@
 import { readFile, readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { runMDRWithDetails } from "@/lib/utils/runMDR";
-import { slimHtml } from "@wordbricks/next-eval/html/utils/slimHtml";
-import type { TagNode } from "@wordbricks/next-eval/shared/interfaces/TagNode";
+import { type TagNode, slimHtml } from "@wordbricks/next-eval";
 import { JSDOM } from "jsdom";
 import { beforeAll, describe, expect, it } from "vitest";
 

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -129,7 +129,7 @@
       "**/.next",
       "**/dist",
       "**/node_modules",
-      "**/rust_mdr_pkg/*.js",
+      "**/rust_mdr_pkg",
       "**/pkg/*.js",
       "**/.claude/settings.local.json",
       "apps/web/src/assets/**"

--- a/packages/next-eval/package.json
+++ b/packages/next-eval/package.json
@@ -2,7 +2,13 @@
   "name": "@wordbricks/next-eval",
   "version": "0.0.1",
   "type": "module",
+  "main": "./src/index.ts",
+  "module": "./src/index.ts",
+  "types": "./src/index.ts",
+  "sideEffects": false,
   "exports": {
+    ".": "./src/index.ts",
+    "./server": "./src/server.ts",
     "./*": "./src/*.ts"
   },
   "scripts": {

--- a/packages/next-eval/src/evaluation/utils/calculateEvaluationMetrics.ts
+++ b/packages/next-eval/src/evaluation/utils/calculateEvaluationMetrics.ts
@@ -41,7 +41,7 @@ export const calculateEvaluationMetrics = (
 
   // Use munkres to find the optimal assignment (indices of matched pairs)
   // munkres-js handles rectangular matrices
-  const K = Math.min(M, N);
+  const _K = Math.min(M, N);
   const assignmentIndices: [number, number][] = munkres(costMatrix); // Returns array of pairs [predIndex, gtIndex]
 
   // Calculate the total overlap sum from the optimal matching

--- a/packages/next-eval/src/evaluation/utils/mapResponseToFullXpath.ts
+++ b/packages/next-eval/src/evaluation/utils/mapResponseToFullXpath.ts
@@ -22,7 +22,7 @@ export const mapResponseToFullXpath = (
           }
           if (!/\[\d+\]$/.test(segment)) {
             // If segment is not empty and does not end with [number]
-            return segment + "[1]";
+            return `${segment}[1]`;
           }
           return segment;
         });

--- a/packages/next-eval/src/html/utils/extractTextWithXPaths.ts
+++ b/packages/next-eval/src/html/utils/extractTextWithXPaths.ts
@@ -1,4 +1,4 @@
-import type { NestedTextMap } from "@wordbricks/next-eval/shared/interfaces/HtmlResult";
+import type { NestedTextMap } from "../../shared/interfaces/HtmlResult";
 import { generateXPath } from "./generateXPath";
 
 // Helper function to extract text and build flat/hierarchical maps

--- a/packages/next-eval/src/html/utils/processHtmlContent.ts
+++ b/packages/next-eval/src/html/utils/processHtmlContent.ts
@@ -1,4 +1,4 @@
-import type { NestedTextMap } from "@wordbricks/next-eval/shared/interfaces/HtmlResult";
+import type { NestedTextMap } from "../../shared/interfaces/HtmlResult";
 import { extractTextWithXPaths } from "./extractTextWithXPaths";
 import { slimHtml } from "./slimHtml";
 

--- a/packages/next-eval/src/index.ts
+++ b/packages/next-eval/src/index.ts
@@ -1,0 +1,31 @@
+// Shared interfaces and types
+export * from "./shared/interfaces/types";
+export * from "./shared/interfaces/LLMResponse";
+export * from "./shared/interfaces/HtmlResult";
+export * from "./shared/interfaces/TagNode";
+
+// Shared utilities
+export * from "./shared/utils/buildTagTree";
+
+// Evaluation interfaces
+export * from "./evaluation/interfaces/EvaluationResult";
+
+// Evaluation utilities
+export * from "./evaluation/utils/calculateEvaluationMetrics";
+export * from "./evaluation/utils/calculateOverlap";
+export * from "./evaluation/utils/mapResponseToFullXpath";
+
+// HTML processing utilities
+export * from "./html/utils/extractTextWithXPaths";
+export * from "./html/utils/generateXPath";
+export * from "./html/utils/processHtmlContent";
+export * from "./html/utils/removeCommentScriptStyleFromHTML";
+export * from "./html/utils/slimHtml";
+
+// LLM constants
+export * from "./llm/constants";
+
+// LLM utilities
+export * from "./llm/utils/compile";
+// Note: getLLMResponse is excluded as it depends on promptLoader which uses Node.js APIs
+// Import from @wordbricks/next-eval/server for server-side usage

--- a/packages/next-eval/src/llm/prompts/promptLoader.ts
+++ b/packages/next-eval/src/llm/prompts/promptLoader.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import type { PromptType } from "@wordbricks/next-eval/shared/interfaces/types";
+import type { PromptType } from "../../shared/interfaces/types";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/packages/next-eval/src/llm/utils/getLLMResponse.ts
+++ b/packages/next-eval/src/llm/utils/getLLMResponse.ts
@@ -1,9 +1,9 @@
 import { google } from "@ai-sdk/google";
-import { loadPromptContent } from "@wordbricks/next-eval/llm/prompts/promptLoader";
-import type { LLMUsage } from "@wordbricks/next-eval/shared/interfaces/LLMResponse";
-import type { PromptType } from "@wordbricks/next-eval/shared/interfaces/types";
 import { generateText } from "ai";
+import type { LLMUsage } from "../../shared/interfaces/LLMResponse";
+import type { PromptType } from "../../shared/interfaces/types";
 import { GEMINI_PRO_2_5_PREVIEW_03 } from "../constants";
+import { loadPromptContent } from "../prompts/promptLoader";
 
 export const getLLMResponse = async (
   data: string,

--- a/packages/next-eval/src/server.ts
+++ b/packages/next-eval/src/server.ts
@@ -1,0 +1,9 @@
+// Server-side only exports for @wordbricks/next-eval
+// These exports use Node.js APIs and should only be imported in server environments
+
+// Re-export everything from the main index (client-safe exports)
+export * from "./index";
+
+// Server-only exports
+export * from "./llm/prompts/promptLoader";
+export * from "./llm/utils/getLLMResponse";

--- a/packages/next-eval/src/shared/utils/buildTagTree.ts
+++ b/packages/next-eval/src/shared/utils/buildTagTree.ts
@@ -1,10 +1,10 @@
-import type { TagNode } from "@wordbricks/next-eval/shared/interfaces/TagNode";
 import {
   type HTMLElement,
   type Node,
   NodeType,
   type TextNode,
 } from "node-html-parser";
+import type { TagNode } from "../interfaces/TagNode";
 
 export function buildTagTree(domNode: Node, parentElementXPath = ""): TagNode {
   if (!domNode) {


### PR DESCRIPTION
```
import {
  type ExtendedHtmlResult,
  mapResponseToFullXpath,
  processHtmlContent,
} from "@wordbricks/next-eval";

```

이런 식으로 쓸 수 있게 barrel file 추가

package.json 에 side effect: false 설정해서 tree shaking 일어남 (= 안 쓰는 코드 제거)