### PR TITLE
feat: deploy setup

### DIFF
--- a/packages/next-eval/LICENSE
+++ b/packages/next-eval/LICENSE
@@ -1,0 +1,8 @@
+The MIT License (MIT)
+Copyright © 2025 <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE..

--- a/packages/next-eval/README.md
+++ b/packages/next-eval/README.md
@@ -1,0 +1,15 @@
+# @wordbricks/next-eval
+
+Web data record extraction and evaluation library.
+
+## Installation
+
+```bash
+npm install @wordbricks/next-eval
+```
+
+## Usage
+
+```typescript
+import { /* your imports */ } from '@wordbricks/next-eval';
+```

--- a/packages/next-eval/package.json
+++ b/packages/next-eval/package.json
@@ -1,19 +1,36 @@
 {
   "name": "@wordbricks/next-eval",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "type": "module",
-  "main": "./src/index.ts",
-  "module": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "sideEffects": false,
-  "exports": {
-    ".": "./src/index.ts",
-    "./server": "./src/server.ts",
-    "./*": "./src/*.ts"
+  "typesVersions": {
+    "*": {
+      "*": ["./dist/*"],
+      "server": ["./dist/server.d.ts"]
+    }
   },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./server": {
+      "types": "./dist/server.d.ts",
+      "import": "./dist/server.js",
+      "default": "./dist/server.js"
+    }
+  },
+  "files": ["dist", "README.md", "LICENSE"],
   "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
     "lint": "biome check --diagnostic-level=error",
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "prepublishOnly": "bun run clean && bun run build"
   },
   "dependencies": {
     "node-html-parser": "^7.0.1",
@@ -30,5 +47,10 @@
     "typescript": "5.8.3",
     "@types/mustache": "^4.2.6"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/wordbricks/next-eval.git"
+  },
+  "license": "MIT",
   "packageManager": "bun@1.2.15"
 }


### PR DESCRIPTION
https://www.npmjs.com/package/@wordbricks/next-eval

아래와 같이 import 가능합니다 (`.../server` directory는 prompt 가져올 때 node API 써서 루트에 두면 에러 나는데, 요거 해결해야 하나로 통일 가능... 일단은 일케 했어요)

```ts
// Test TypeScript imports and types
import { processHtmlContent, buildTagTree } from '@wordbricks/next-eval';
import { getLLMResponse } from '@wordbricks/next-eval/server';

// This should compile without errors now
console.log('TypeScript types resolved correctly');

// Runtime test
console.log('Imports work:', {
  processHtmlContent: typeof processHtmlContent,
  buildTagTree: typeof buildTagTree,
  getLLMResponse: typeof getLLMResponse
});
```

```ts
// Test valid imports
import { processHtmlContent, buildTagTree } from '@wordbricks/next-eval';
import { getLLMResponse } from '@wordbricks/next-eval/server';

console.log('✅ Valid imports work:', {
  processHtmlContent: typeof processHtmlContent,
  buildTagTree: typeof buildTagTree,
  getLLMResponse: typeof getLLMResponse
});
```


```ts
// Test valid imports in TypeScript
import { processHtmlContent, buildTagTree } from '@wordbricks/next-eval';
import { getLLMResponse } from '@wordbricks/next-eval/server';

console.log('✅ Valid imports work:', {
  processHtmlContent: typeof processHtmlContent,
  buildTagTree: typeof buildTagTree,
  getLLMResponse: typeof getLLMResponse
});
```






아래와 같이 import 하는 것은 방지합니다:

```ts
// Test invalid imports - these should fail
try {
  await import('@wordbricks/next-eval/evaluation/utils/calculateEvaluationMetrics.js');
  console.log('❌ Direct deep import should have failed');
} catch (error) {
  console.log('✅ Direct deep import blocked:', error.code);
}

try {
  await import('@wordbricks/next-eval/shared/utils/buildTagTree.js');
  console.log('❌ Another deep import should have failed');
} catch (error) {
  console.log('✅ Another deep import blocked:', error.code);
}
```